### PR TITLE
Fix infinite research possibility on waspite medic.

### DIFF
--- a/Ruleset/research_FMP.rul
+++ b/Ruleset/research_FMP.rul
@@ -1944,7 +1944,6 @@
       - STR_GAZER
       - STR_CHTONITE
       - STR_CHASER
-      - STR_CEREBREAL
       - STR_HOLODRONE
       - STR_SALAMANDRON
       - STR_CEREBREAL


### PR DESCRIPTION
A duplicate ID under `getOneFree` prevents the engine (in it's current state) from recognizing all free ones are already researched.
Hence this topic will always be available for research (with enough alive medics in containment). The score (points) is only awarded once though, upon first completion.

Two additional remarks:
* This was the only duplicate i found in the research file
* Only happens in OXC (OXCE seem to have some protection preventing this)