### PR TITLE
Fixed: gauss/rail HWPs needed 60 clips to deploy.

### DIFF
--- a/Ruleset/items_FMP.rul
+++ b/Ruleset/items_FMP.rul
@@ -2889,6 +2889,7 @@
     handSprite: 0
     bulletSprite: 19
     fireSound: 65
+    clipSize: 60
     compatibleAmmo:
       - STR_HWP_GAUSS_AMMO
     accuracySnap: 70
@@ -2911,6 +2912,7 @@
     handSprite: 0
     bulletSprite: 19
     fireSound: 86
+    clipSize: 60
     compatibleAmmo:
       - STR_HWP_GAUSS_AMMO
     accuracySnap: 50
@@ -2948,6 +2950,7 @@
     handSprite: 0
     bulletSprite: 18
     fireSound: 96
+    clipSize: 60
     compatibleAmmo:
       - STR_HWP_RAILGUN_AMMO
     accuracyAuto: 35
@@ -2972,6 +2975,7 @@
     handSprite: 0
     bulletSprite: 18
     fireSound: 96
+    clipSize: 60
     compatibleAmmo:
       - STR_HWP_RAILGUN_AMMO
     accuracySnap: 50


### PR DESCRIPTION
I believe one HWP gauss/railgun clip should contain 60 ammo because it has similar cost of gauss/railgun fighter cannon clip. But 60 clips must be manufactured before HWPs can be deployed. Maybe it's a bug?